### PR TITLE
Automatically releasing all versions as Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
+ARG EMQ_VERSION=v2.3.7
 FROM alpine:3.7
 
 MAINTAINER Huang Rui <vowstar@gmail.com>, Turtle <turtled@emqtt.io>
-
-ENV EMQ_VERSION=v2.3.7
 
 COPY ./start.sh /start.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-ARG EMQ_VERSION=v2.3.7
 FROM alpine:3.7
 
 MAINTAINER Huang Rui <vowstar@gmail.com>, Turtle <turtled@emqtt.io>
+
+# Arrange to be able to build all available tagged versions, but also pass the
+# version built into the container.
+ARG EMQ_VERSION=v2.3.7
+ENV EMQ_VERSION ${EMQ_VERSION}
 
 COPY ./start.sh /start.sh
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Would you want to select another version of EMQ, you could use the `--build-arg`
 option, as exemplified below:
 
 ```bash
-docker build --build-arg=EMQ_VERSION=v2.3.6 -t emq:v2.3.6 .
+docker build --build-arg EMQ_VERSION=v2.3.6 -t emq:v2.3.6 .
 ```
 
 ### Run emqttd

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ cd emq_docker
 docker build -t emq:latest .
 ```
 
+Would you want to select another version of EMQ, you could use the `--build-arg`
+option, as exemplified below:
+
+```bash
+docker build --build-arg=EMQ_VERSION=v2.3.6 -t emq:v2.3.6 .
+```
+
 ### Run emqttd
 
 Execute some command under this docker image
@@ -194,6 +201,11 @@ docker run --rm -ti --name emq -p 18083:18083 -p 1883:1883 -p 4369:4369 \
 ```
 
 > REMEMBER: DO NOT RUN EMQ DOCKER PRIVILEGED OR MOUNT SYSTEM PROC IN CONTAINER TO TUNE LINUX KERNEL, IT IS UNSAFE.
+
+### Automated Builds
+
+The scripts in the [hooks](/hooks) directory arrange for the Docker hub to
+automatically (re)build images for all official releases of EMQ.
 
 ### Thanks
 

--- a/hooks/build
+++ b/hooks/build
@@ -3,12 +3,14 @@
 EMQ_REPO="emqtt/emqttd"
 RELEASES=$(curl -qsL https://api.github.com/repos/${EMQ_REPO}/tags | grep \"name\"|grep -v "rc"|grep -v "beta"|grep -v "alpha"|sed "s/^\s*\"name\"\s*:\s*\"\(v\([0-9]\+\.\)\+[0-9]\+\\)\"\s*,/\1/g")
 
+latest=$(echo ${RELEASES}|cut -d" " -f1)
 IMG=$(basename $DOCKER_REPO)
 for tag in ${RELEASES}; do
-    echo "============== Building ${IMG}:$tag"
-    docker build --build-arg EMQ_VERSION=$tag -t ${DOCKER_REPO}:$tag .
+    if [ "$tag" == "$latest" ]; then
+        echo "============== Building ${IMG}:$tag as ${IMG}:latest"
+        docker build --build-arg EMQ_VERSION=$tag -t ${DOCKER_REPO}:$tag -t ${DOCKER_REPO}:latest .
+    else
+        echo "============== Building ${IMG}:$tag"
+        docker build --build-arg EMQ_VERSION=$tag -t ${DOCKER_REPO}:$tag .
+    fi
 done
-
-# Tag the top one as latest
-latest=$(echo ${RELEASES}|cut -d" " -f1)
-docker tag ${DOCKER_REPO}:$latest ${DOCKER_REPO}:latest

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+EMQ_REPO="emqtt/emqttd"
+RELEASES=$(curl -qsL https://api.github.com/repos/${EMQ_REPO}/tags | grep \"name\"|grep -v "rc"|grep -v "beta"|grep -v "alpha"|sed "s/^\s*\"name\"\s*:\s*\"\(v\([0-9]\+\.\)\+[0-9]\+\\)\"\s*,/\1/g")
+
+IMG=$(basename $DOCKER_REPO)
+for tag in ${RELEASES}; do
+    echo "============== Building ${IMG}:$tag"
+    docker build --build-arg EMQ_VERSION=$tag -t ${DOCKER_REPO}:$tag .
+done
+
+# Tag the top one as latest
+latest=$(echo ${RELEASES}|cut -d" " -f1)
+docker tag ${DOCKER_REPO}:$latest ${DOCKER_REPO}:latest

--- a/hooks/push
+++ b/hooks/push
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+EMQ_REPO="emqtt/emqttd"
+RELEASES=$(curl -qsL https://api.github.com/repos/${EMQ_REPO}/tags | grep \"name\"|grep -v "rc"|grep -v "beta"|grep -v "alpha"|sed "s/^\s*\"name\"\s*:\s*\"\(v\([0-9]\+\.\)\+[0-9]\+\\)\"\s*,/\1/g")
+
+IMG=$(basename $DOCKER_REPO)
+for tag in ${RELEASES}; do
+    echo "============== Pushing ${IMG}:$tag"
+    docker push ${DOCKER_REPO}:$tag
+done
+echo "============== Pushing ${IMG}:latest"
+docker push ${DOCKER_REPO}:latest


### PR DESCRIPTION
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation README.md.

This PR does two (intertwined) things:
1. It migrates the EMQ version number to a Docker [build argument](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) without changing the original behaviour. An environment variable is still passed further to containers running the image, for backwards compatibility.
2. It creates two hooks script that will arrange for the docker hub to automatically (re)build *all* official releases of EMQ. Release numbers are taken from the version tags at github, meaning that the logic will keep working for future releases. This leads to automatically providing docker images tagged with the same version number (and same code) as each of the official EMQ release. An example is provided [here](https://hub.docker.com/r/efrecon/emq/tags/). All image releases will be based on `alpine:3.7`. Setting `alpine` as a dependency on the hub will ensure that every (security) improvement to the underlying alpine image will be reflected onto all releases of EMQ.