### PR TITLE
Add in tini for proper signal propogation inside docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,10 +88,13 @@ RUN set -ex \
     && ln -s /opt/emqttd/bin/* /usr/local/bin/ \
     # removing fetch deps and build deps
     && apk --purge del .build-deps .fetch-deps \
-    && rm -rf /var/cache/apk/*
+    && rm -rf /var/cache/apk/* \
+    && wget https://github.com/krallin/tini/releases/download/v0.18.0/tini-muslc-amd64 -O /usr/local/bin/tini \
+    && chmod +x /usr/local/bin/tini
 
 WORKDIR /opt/emqttd
 
+ENTRYPOINT ["/usr/local/bin/tini", "--"]
 # start emqttd and initial environments
 CMD ["/opt/emqttd/start.sh"]
 


### PR DESCRIPTION
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation README.md.   

The change adds [TINI](https://github.com/krallin/tini), an init manager to the docker container, this ensures that when docker stop is called, the signal gets properly propagated to the erlang process, right now only the shell script got the signal and it didn't do anything about it(resulting in a sigkill after a timeout).

With this change the erlang process will get the SIGTERM and properly shutdown.(Needs to be handled inside emqttd)

TINI was used over other init systems because it's extremely small and does the job well. (Docker uses this if you use the `--init` option).