### PR TITLE
Fix image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,23 +4,23 @@ MAINTAINER Huang Rui <vowstar@gmail.com>, EMQ X Team <support@emqx.io>
 
 ENV OTP_VERSION="21.0.7"
 
-COPY ./start.sh /start.sh
 
 RUN set -xe \
         && OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
         && OTP_DOWNLOAD_SHA256="4e9c98b5f29918d0896b21ce28b13c7928d4c9bd6a0c7d23b4f19b27f6e3b6f7" \
         && apk add --no-cache --virtual .fetch-deps \
                 curl \
-                bsd-compat-headers \
                 ca-certificates \
-        && curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
-        && echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
+        && apk add --no-cache --virtual .erlang-rundeps lksctp-tools \
+                ncurses \
+                unixodbc \
+                openssl \
         && apk add --no-cache --virtual .build-deps \
-                dpkg-dev dpkg \
                 gcc \
                 g++ \
                 libc-dev \
                 linux-headers \
+                bsd-compat-headers \
                 make \
                 autoconf \
                 ncurses-dev \
@@ -30,14 +30,15 @@ RUN set -xe \
                 tar \
                 git \
                 wget \
+        && curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
+        && (echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - ) \
         && export ERL_TOP="/usr/src/otp_src_${OTP_VERSION%%@*}" \
         && mkdir -vp $ERL_TOP \
         && tar -xzf otp-src.tar.gz -C $ERL_TOP --strip-components=1 \
         && rm otp-src.tar.gz \
         && ( cd $ERL_TOP \
           && ./otp_build autoconf \
-          && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
-          && ./configure --build="$gnuArch" \
+          && ./configure --build=x86_64-alpine-linux-musl \
           && make -j$(getconf _NPROCESSORS_ONLN) \
           && make install ) \
         && rm -rf $ERL_TOP \
@@ -46,31 +47,30 @@ RUN set -xe \
         && find /usr/local -name src | xargs -r find | xargs rmdir -vp || true \
         && scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs -r strip --strip-all \
         && scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local | xargs -r strip --strip-unneeded \
-        && runDeps="$( \
-                scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
-                        | tr ',' '\n' \
-                        | sort -u \
-                        | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-        )" \
-        && apk add --virtual .erlang-rundeps $runDeps lksctp-tools
+        && apk del --purge .fetch-deps .build-deps
 
 ENV EMQX_VERSION=v3.0-beta.3
 
 RUN set -ex \
-        cd / && git clone -b ${EMQX_VERSION} https://github.com/emqx/emqx-rel /emqx \
+        && apk add --no-cache --virtual .build-deps \
+                bsd-compat-headers \
+                gcc \
+                g++ \
+                make \
+                tar \
+                git \
+                perl \
+        && cd / \
+        && git clone -b ${EMQX_VERSION} https://github.com/emqx/emqx-rel /emqx \
         && cd /emqx \
         && make \
         && mkdir -p /opt && mv /emqx/_rel/emqx /opt/emqx \
         && cd / && rm -rf /emqx \
-        && mv /start.sh /opt/emqx/start.sh \
-        && chmod +x /opt/emqx/start.sh \
         && ln -s /opt/emqx/bin/* /usr/local/bin/ \
-        # removing fetch deps and build deps
-		&& apk --purge del .build-deps .fetch-deps \
-        && rm -rf /var/cache/apk/* \
-        && rm -rf /usr/local/lib/erlang
+        && apk --purge del .build-deps 
 
 WORKDIR /opt/emqx
+COPY ./start.sh ./
 
 # start emqx and initial environments
 CMD ["/opt/emqx/start.sh"]


### PR DESCRIPTION
Last change to emqx Dockerfile separate the build of otp and emqx. However the installed package used to build otp was not removed from the otp layer, thus increasing the final image size no matter whether they're removed or not. 
This pull request fix the above issue.