### PR TITLE
Move curl installation to `apt-get purge` RUN line

### DIFF
--- a/5.2/Dockerfile
+++ b/5.2/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:11-slim
 
 RUN set -eu; \
     apt-get update; \
-    apt-get install -y --no-install-recommends curl ca-certificates procps; \
+    apt-get install -y --no-install-recommends ca-certificates procps; \
     rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -r -g 1000 emqx; \
@@ -14,6 +14,9 @@ ENV ARM64_SHA256=b4991f1f7d44963ad7ff0fd65234f9ae39298ea43d9fa8b009035d649e4c17d
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 
 RUN set -eu; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends curl; \
+    rm -rf /var/lib/apt/lists/*; \
     arch=$(dpkg --print-architecture); \
     if [ ${arch} = "amd64" ]; then sha256="$AMD64_SHA256"; fi; \
     if [ ${arch} = "arm64" ]; then sha256="$ARM64_SHA256"; fi; \


### PR DESCRIPTION
This move ensures that the `apt-get purge` of `curl` lines up with its installation to prevent the image from being larger than necessary with files that are inaccessible in the final image.

Only `5.2` was updated since it is the only one with the `apt-get purge`.

Follow up to https://github.com/docker-library/official-images/pull/15380